### PR TITLE
Fixed broken links to source code files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,45 +24,43 @@ MiniSTL
 
  2. **迭代器与traits编程技法（iterator && traits)**
 
- &emsp;[iterator_traits(stl_iterator.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Iterator%20and%20Traits/stl_iterator.h):100%  
+ &emsp;[iterator_traits(stl_iterator.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Iterator/stl_iterator.h):100%  
 
- &emsp;[type_traits(type_traits.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Iterator%20and%20Traits/typeTraits.h):100%  
+ &emsp;[type_traits(type_traits.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Iterator/typeTraits.h):100%  
 
  3. **序列式容器（sequence containers)**
 
- &emsp;[vector(stl_vector.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Sequence%20containers/Vector/stl_vector.h):100%  
+ &emsp;[vector(stl_vector.h)](https://github.com/zsmj2017/MiniSTL/blob/master/SequenceContainers/Vector/stl_vector.h):100%  
 
- &emsp;[list(stl_list.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Sequence%20containers/List/stl_list.h):100%   
+ &emsp;[list(stl_list.h)](https://github.com/zsmj2017/MiniSTL/blob/master/SequenceContainers/List/stl_list.h):100%   
 
- &emsp;[deque(stl_deque.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Sequence%20containers/Deque/stl_deque.h):100%  
+ &emsp;[deque(stl_deque.h)](https://github.com/zsmj2017/MiniSTL/blob/master/SequenceContainers/Deque/stl_deque.h):100%  
 
- &emsp;[stack(stl_stack.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Sequence%20containers/Stack/stl_stack.h):100%  
+ &emsp;[stack(stl_stack.h)](https://github.com/zsmj2017/MiniSTL/blob/master/SequenceContainers/Stack/stl_stack.h):100%  
 
- &emsp;[queue(stl_queue.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Sequence%20containers/Queue/stl_queue.h):100%   
+ &emsp;[queue(stl_queue.h)](https://github.com/zsmj2017/MiniSTL/blob/master/SequenceContainers/Queue/stl_queue.h):100%   
 
- &emsp;[priority_queue(priority_queue.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Sequence%20containers/Priority_Queue/stl_priority_queue.h):100%  
-
- &emsp;[slist(slist.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Sequence%20containers/Slist/slist.h):100%  
+ &emsp;[slist(slist.h)](https://github.com/zsmj2017/MiniSTL/blob/master/SequenceContainers/Slist/slist.h):100%  
 
  4. **关联式容器(associattive containers)**
 
- &emsp;[rb_tree(rb_tree.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Associative%20containers/RB-Tree/rb_tree.h):100%  
+ &emsp;[rb_tree(rb_tree.h)](https://github.com/zsmj2017/MiniSTL/blob/master/AssociativeContainers/RB-Tree/rb_tree.h):100%  
 
- &emsp;[set(stl_set.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Associative%20containers/Set/stl_set.h):100%  
+ &emsp;[set(stl_set.h)](https://github.com/zsmj2017/MiniSTL/blob/master/AssociativeContainers/Set/stl_set.h):100%  
 
- &emsp;[map(stl_map.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Associative%20containers/Map/stl_map.h):100%  
+ &emsp;[map(stl_map.h)](https://github.com/zsmj2017/MiniSTL/blob/master/AssociativeContainers/Map/stl_map.h):100%  
 
- &emsp;[multiset(stl_multiset.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Associative%20containers/Mutiset/stl_mutiset.h):100%  
+ &emsp;[multiset(stl_multiset.h)](https://github.com/zsmj2017/MiniSTL/blob/master/AssociativeContainers/Multiset/stl_multiset.h):100%  
 
- &emsp;[multimap(stl_multimap.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Associative%20containers/Mutimap/stl_mutimap.h):100%  
+ &emsp;[multimap(stl_multimap.h)](https://github.com/zsmj2017/MiniSTL/blob/master/AssociativeContainers/Multimap/stl_multimap.h):100%  
 
- &emsp;[hashtable(hashtable.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Associative%20containers/Hashmap/hash_map.h):100%  
+ &emsp;[hashtable(hashtable.h)](https://github.com/zsmj2017/MiniSTL/blob/master/AssociativeContainers/Hashmap/hash_map.h):100%  
 
- &emsp;[hashset(hashset.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Associative%20containers/Hashset/hash_set.h):100%  
+ &emsp;[hashset(hashset.h)](https://github.com/zsmj2017/MiniSTL/blob/master/AssociativeContainers/Hashset/hash_set.h):100%  
 
- &emsp;[hashmultiset(hash_multiset.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Associative%20containers/HashMultiset/hash_multiset.h):100%  
+ &emsp;[hashmultiset(hash_multiset.h)](https://github.com/zsmj2017/MiniSTL/blob/master/AssociativeContainers/HashMultiset/hash_multiset.h):100%  
 
- &emsp;[hashmultimap(hash_multimap.h)](https://github.com/zsmj2017/MiniSTL/blob/master/Associative%20containers/HashMultiset/hash_multimap.h):100%  
+ &emsp;[hashmultimap(hash_multimap.h)](https://github.com/zsmj2017/MiniSTL/blob/master/AssociativeContainers/HashMultimap/hash_multimap.h):100%  
 
  5. **算法（algorithm)**
 


### PR DESCRIPTION
- Replace paths with correct characters.
- Removed the priority_queue(priority_queue.h) link because the file was removed at `970056357f7b88d44e82fa72222d92ab783a2084`.